### PR TITLE
Remove "steamcommunity.com"

### DIFF
--- a/domain_blocklist_recommended.txt
+++ b/domain_blocklist_recommended.txt
@@ -32580,7 +32580,6 @@ steamcommuniqy.com
 steamcommunitlu.com
 steamcommunitn.com
 steam.communityartworkstore.com
-steamcommunity.com
 steamcommunity-comprofiles76561199018097392.ru
 steam.communitydetailsworkshop.com
 steamcommunityforums.com


### PR DESCRIPTION
Removed "steamcommunity.com" from the blocklist as it is no considered a harmful or unsafe website.